### PR TITLE
Fix CleanupViewModel

### DIFF
--- a/lua/weapons/oni_base/cl_viewmodel.lua
+++ b/lua/weapons/oni_base/cl_viewmodel.lua
@@ -26,11 +26,8 @@ function SWEP:ResetBoneMod(ent)
 end
 
 function SWEP:CleanupViewModel()
-	local owner = self:GetOwner()
+	local owner = LocalPlayer()
 	if not IsValid(owner) then
-		return
-	end
-	if owner ~= LocalPlayer() then
 		return
 	end
 


### PR DESCRIPTION
I noticed that when dropping a swep where something was done with BoneManip the viemodel didn't get reset.
Resulting into this:
![image](https://github.com/oninoni/swep_base_oni/assets/99217547/150a75d7-15a5-4b13-8319-eaa09fd0b8cc)

It seems that the owner was always invalid. To fix this I changed it so that it would get the local player, since this is a clientside script.

NOTE: 
I believe this issue wasn't noticeable to the tricorder and PADD since they weren't changing any bones that existed on the other viewmodels.