### PR TITLE
Add bodygroup support

### DIFF
--- a/lua/weapons/oni_base/cl_init.lua
+++ b/lua/weapons/oni_base/cl_init.lua
@@ -79,6 +79,7 @@ function SWEP:DrawWorldModel(flags)
 		self.CustomWorldModelEntity:SetAngles(ang)
 
 		self.CustomWorldModelEntity:SetSkin(self:GetSkin())
+		self.CustomWorldModelEntity:SetBodyGroups(self:GetNWString("Oni_base.bodyGroups"))
 
 		self.CustomWorldModelEntity:DrawModel(flags)
 	else

--- a/lua/weapons/oni_base/cl_viewmodel.lua
+++ b/lua/weapons/oni_base/cl_viewmodel.lua
@@ -105,6 +105,7 @@ function SWEP:PostDrawViewModel(vm, weapon, ply)
 		self.CustomViewModelEntity:SetAngles(ang)
 
 		self.CustomViewModelEntity:SetSkin(self:GetSkin())
+		self.CustomViewModelEntity:SetBodyGroups(self:GetNWString("Oni_base.bodyGroups"))
 
 		self.CustomViewModelEntity:DrawModel()
 	end


### PR DESCRIPTION
Making the different star trek tools I really needed bodygroup support. So I made this pull request.

To change the body group the SWEP just has to do this:
```lua
self:SetNWString("Oni_base.bodyGroups", "01")
```

If you have a better way to do this please tell me :)

**PS:** From my testing, I found out that you can't just do `self:SetBodyGroups("000")` , because it will change the body group of SWEP.ViewModel which in most cases is a bug bait or `v_pistol.mdl`