### PR TITLE
Add `SWEP:HolsterCustom()` and `SWEP:OnRemoveCustom()` function support

### DIFF
--- a/lua/weapons/oni_base/cl_viewmodel.lua
+++ b/lua/weapons/oni_base/cl_viewmodel.lua
@@ -47,10 +47,16 @@ end
 
 function SWEP:Holster(weapon)
 	self:CleanupViewModel()
+	if isfunction(self.HolsterCustom) then
+		self:HolsterCustom(weapon)
+	end
 end
 
 function SWEP:OnRemove()
 	self:CleanupViewModel()
+	if isfunction(self.OnRemoveCustom) then
+		self:OnRemoveCustom()
+	end
 end
 
 net.Receive("OniBase.ResetViewModel", function()


### PR DESCRIPTION
I noticed that I couldn't add my own `SWEP:Holster()` and `SWEP:OnRemove()` functions since it will than override the ViewModel clean up, meaning bones would break for other weapons.

To fix this I did the same you did with `SWEP:Initialize()` by running `SWEP:HolsterCustom()` and `SWEP:OnRemoveCustom()` after the viewmodel has been cleaned up.